### PR TITLE
[PXP-8919] feat: update Docker image to Go 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,22 @@
-FROM golang:1.14-alpine
+FROM quay.io/cdis/golang:1.17-bullseye as build-deps
+
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
 
 WORKDIR /go/src/github.com/abutaha/aws-es-proxy
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go build -o aws-es-proxy
+RUN go build -o /aws-es-proxy
 
-FROM alpine:3.11
 LABEL name="aws-es-proxy" \
       version="latest"
 
-RUN apk --no-cache add ca-certificates
-WORKDIR /home/
-COPY --from=0 /go/src/github.com/abutaha/aws-es-proxy/aws-es-proxy /usr/local/bin/
-
-ENV PORT_NUM 9200
-EXPOSE ${PORT_NUM}
-
-ENTRYPOINT ["aws-es-proxy"] 
+ENTRYPOINT ["/aws-es-proxy"] 
 CMD ["-h"]


### PR DESCRIPTION
Jira Ticket: [PXP-8919](https://ctds-planx.atlassian.net/browse/PXP-8919)
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes
* New Docker image with the binary located at `/aws-es-proxy`.

### Bug Fixes


### Improvements
* Updated Docker image to be based on Go 1.17

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
